### PR TITLE
Add minimal tests for quality metrics and Tesseract adapter

### DIFF
--- a/tests/test_ocr_tesseract_adapter.py
+++ b/tests/test_ocr_tesseract_adapter.py
@@ -1,29 +1,43 @@
 import io
-import shutil
+
 import pytest
 from PIL import Image, ImageDraw
+
+import pytesseract
+
 from shared.ocr.adapters.tesseract import TesseractAdapter
 
 
-def test_tesseract_adapter_process():
-    """Test TesseractAdapter with a simple text image."""
-    if shutil.which("tesseract") is None:
-        pytest.skip("Tesseract binary not found - skipping test")
+def _require_tesseract():
+    try:
+        pytesseract.get_tesseract_version()
+    except (pytesseract.TesseractNotFoundError, OSError, RuntimeError) as exc:
+        pytest.skip(f"Tesseract binary not available: {exc}")
 
-    # Create a tiny test image with text
-    img = Image.new('RGB', (200, 50), color='white')
+
+def _make_text_image(text: str) -> bytes:
+    img = Image.new("RGB", (220, 80), color="white")
     draw = ImageDraw.Draw(img)
+    draw.text((10, 25), text, fill="black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
 
-    # Draw simple text
-    draw.text((10, 15), "TEST", fill='black')
 
-    # Convert to bytes
-    img_bytes = io.BytesIO()
-    img.save(img_bytes, format='PNG')
-    content = img_bytes.getvalue()
-
-    # Test the adapter
+def test_tesseract_adapter_extracts_text():
+    _require_tesseract()
+    content = _make_text_image("Hello OCR")
     adapter = TesseractAdapter()
+
     result = adapter.process(content, "image/png", languages=["eng"])
 
-    assert result.combined_text.strip() != "", "Expected non-empty OCR text"
+    assert result.combined_text.strip() != ""
+    assert result.pages[0].text.strip() != ""
+
+
+def test_tesseract_adapter_handles_non_images():
+    adapter = TesseractAdapter()
+    result = adapter.process(b"not an image", "application/pdf")
+
+    assert result.combined_text == ""
+    assert result.pages[0].confidence == 0.0

--- a/tests/test_quality_metrics_basic.py
+++ b/tests/test_quality_metrics_basic.py
@@ -1,0 +1,44 @@
+import cv2
+import numpy as np
+
+from shared.quality.metrics import compute_metrics_and_warnings
+
+
+def _png_bytes_from_image(img: np.ndarray) -> bytes:
+    success, buf = cv2.imencode(".png", img)
+    if not success:
+        raise RuntimeError("Failed to encode png for test")
+    return buf.tobytes()
+
+
+def test_quality_metrics_good_image_has_minimal_warnings():
+    # Create a sharp synthetic document with clear text.
+    img = np.full((200, 200, 3), 255, dtype=np.uint8)
+    cv2.putText(img, "HELLO OCR WORLD", (5, 110), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (0, 0, 0), 2)
+    png_bytes = _png_bytes_from_image(img)
+
+    ocr_text = "This is a synthetic document that should have sufficient text length for metrics."
+    metrics, warnings = compute_metrics_and_warnings("image/png", png_bytes, ocr_text)
+
+    assert metrics["page_count"] == 1
+    assert metrics["ocr_text_length"] == len(ocr_text)
+    assert metrics["ocr_ok"] is True
+    assert all("blurry" not in w for w in warnings)
+    assert "Very little text extracted" not in " ".join(warnings)
+
+
+def test_quality_metrics_low_quality_image_triggers_warnings():
+    img = np.full((200, 200, 3), 255, dtype=np.uint8)
+    cv2.putText(img, "BLUR", (40, 120), cv2.FONT_HERSHEY_SIMPLEX, 1.6, (0, 0, 0), 5)
+    blurred = cv2.GaussianBlur(img, (29, 29), 0)
+    png_bytes = _png_bytes_from_image(blurred)
+
+    ocr_text = "short text"  # purposely small to trigger density/length warnings
+    metrics, warnings = compute_metrics_and_warnings("image/png", png_bytes, ocr_text)
+
+    assert metrics["page_count"] == 1
+    assert metrics["ocr_ok"] is False
+    joined = " ".join(warnings).lower()
+    assert "blurry" in joined
+    assert "very little text" in joined
+    assert "low text density" in joined


### PR DESCRIPTION
## Summary
- add synthetic image tests for compute_metrics_and_warnings covering sharp vs blurred cases
- refine Tesseract adapter tests with reliable skip when binary missing and non-image handling

## Testing
- .venv/bin/pytest
- ./scripts/ci_smoke.sh
